### PR TITLE
Pin cc to 1.4.0 in CI to fix arm cross-builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,6 +405,10 @@ jobs:
             restore-keys: |
               index-${{ runner.os }}-
         - run: cargo generate-lockfile
+        # cc 1.4.1 passes -mno-omit-leaf-frame-pointer to arm gcc, which
+        # doesn't support it. Remove once the fix for
+        # https://github.com/rust-lang/cc-rs/issues/1844 is released.
+        - run: cargo update -p cc --precise 1.4.0
         - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
           with:
             path: ~/.cargo/registry/cache


### PR DESCRIPTION
cc 1.4.1 (released today) emits `-mno-omit-leaf-frame-pointer` for `arm-unknown-linux-gnueabihf`, but arm gcc doesn't support that flag, so every arm job currently fails while building or probing OpenSSL (visible on #2666, but unrelated to that PR's changes).

Upstream issue: rust-lang/cc-rs#1844. The fix (rust-lang/cc-rs#1845) is merged but not yet released, so pin cc to 1.4.0 in the linux jobs until it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)