### PR TITLE
ssl: add full SslAlert alert descriptions

### DIFF
--- a/openssl-sys/src/handwritten/ssl.rs
+++ b/openssl-sys/src/handwritten/ssl.rs
@@ -540,6 +540,8 @@ extern "C" {
     pub fn SSL_get_error(ssl: *const SSL, ret: c_int) -> c_int;
     pub fn SSL_get_version(ssl: *const SSL) -> *const c_char;
 
+    pub fn SSL_alert_desc_string_long(value: c_int) -> *const c_char;
+
     pub fn SSL_do_handshake(ssl: *mut SSL) -> c_int;
     pub fn SSL_shutdown(ssl: *mut SSL) -> c_int;
 

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -278,9 +278,7 @@ pub const OPENSSL_NPN_UNSUPPORTED: c_int = 0;
 pub const OPENSSL_NPN_NEGOTIATED: c_int = 1;
 pub const OPENSSL_NPN_NO_OVERLAP: c_int = 2;
 
-// TLS alert descriptions, as registered in the IANA TLS Alert registry. The
-// error reason code reported for a received alert is the description plus
-// `SSL_AD_REASON_OFFSET`.
+pub const SSL_AD_REASON_OFFSET: c_int = 1000;
 pub const SSL_AD_CLOSE_NOTIFY: c_int = 0;
 pub const SSL_AD_UNEXPECTED_MESSAGE: c_int = 10;
 pub const SSL_AD_BAD_RECORD_MAC: c_int = 20;
@@ -318,9 +316,6 @@ pub const SSL_AD_UNKNOWN_PSK_IDENTITY: c_int = 115;
 pub const SSL_AD_CERTIFICATE_REQUIRED: c_int = 116;
 pub const SSL_AD_NO_APPLICATION_PROTOCOL: c_int = 120;
 
-/// Offset added to an alert description to obtain the corresponding error
-/// reason code (`SSL_R_*_ALERT_*`).
-pub const SSL_AD_REASON_OFFSET: c_int = 1000;
 pub const SSL_ERROR_NONE: c_int = 0;
 pub const SSL_ERROR_SSL: c_int = 1;
 pub const SSL_ERROR_SYSCALL: c_int = 5;

--- a/openssl-sys/src/ssl.rs
+++ b/openssl-sys/src/ssl.rs
@@ -278,9 +278,49 @@ pub const OPENSSL_NPN_UNSUPPORTED: c_int = 0;
 pub const OPENSSL_NPN_NEGOTIATED: c_int = 1;
 pub const OPENSSL_NPN_NO_OVERLAP: c_int = 2;
 
+// TLS alert descriptions, as registered in the IANA TLS Alert registry. The
+// error reason code reported for a received alert is the description plus
+// `SSL_AD_REASON_OFFSET`.
+pub const SSL_AD_CLOSE_NOTIFY: c_int = 0;
+pub const SSL_AD_UNEXPECTED_MESSAGE: c_int = 10;
+pub const SSL_AD_BAD_RECORD_MAC: c_int = 20;
+pub const SSL_AD_DECRYPTION_FAILED: c_int = 21;
+pub const SSL_AD_RECORD_OVERFLOW: c_int = 22;
+pub const SSL_AD_DECOMPRESSION_FAILURE: c_int = 30;
+pub const SSL_AD_HANDSHAKE_FAILURE: c_int = 40;
+pub const SSL_AD_NO_CERTIFICATE: c_int = 41;
+pub const SSL_AD_BAD_CERTIFICATE: c_int = 42;
+pub const SSL_AD_UNSUPPORTED_CERTIFICATE: c_int = 43;
+pub const SSL_AD_CERTIFICATE_REVOKED: c_int = 44;
+pub const SSL_AD_CERTIFICATE_EXPIRED: c_int = 45;
+pub const SSL_AD_CERTIFICATE_UNKNOWN: c_int = 46;
 pub const SSL_AD_ILLEGAL_PARAMETER: c_int = SSL3_AD_ILLEGAL_PARAMETER;
+pub const SSL_AD_UNKNOWN_CA: c_int = 48;
+pub const SSL_AD_ACCESS_DENIED: c_int = 49;
 pub const SSL_AD_DECODE_ERROR: c_int = TLS1_AD_DECODE_ERROR;
+pub const SSL_AD_DECRYPT_ERROR: c_int = 51;
+pub const SSL_AD_EXPORT_RESTRICTION: c_int = 60;
+pub const SSL_AD_PROTOCOL_VERSION: c_int = 70;
+pub const SSL_AD_INSUFFICIENT_SECURITY: c_int = 71;
+pub const SSL_AD_INTERNAL_ERROR: c_int = 80;
+pub const SSL_AD_INAPPROPRIATE_FALLBACK: c_int = 86;
+pub const SSL_AD_USER_CANCELLED: c_int = 90;
+pub const SSL_AD_NO_RENEGOTIATION: c_int = 100;
+#[cfg(any(ossl111, libressl, boringssl, awslc))]
+pub const SSL_AD_MISSING_EXTENSION: c_int = 109;
+pub const SSL_AD_UNSUPPORTED_EXTENSION: c_int = 110;
+pub const SSL_AD_CERTIFICATE_UNOBTAINABLE: c_int = 111;
 pub const SSL_AD_UNRECOGNIZED_NAME: c_int = TLS1_AD_UNRECOGNIZED_NAME;
+pub const SSL_AD_BAD_CERTIFICATE_STATUS_RESPONSE: c_int = 113;
+pub const SSL_AD_BAD_CERTIFICATE_HASH_VALUE: c_int = 114;
+pub const SSL_AD_UNKNOWN_PSK_IDENTITY: c_int = 115;
+#[cfg(any(ossl111, libressl, boringssl, awslc))]
+pub const SSL_AD_CERTIFICATE_REQUIRED: c_int = 116;
+pub const SSL_AD_NO_APPLICATION_PROTOCOL: c_int = 120;
+
+/// Offset added to an alert description to obtain the corresponding error
+/// reason code (`SSL_R_*_ALERT_*`).
+pub const SSL_AD_REASON_OFFSET: c_int = 1000;
 pub const SSL_ERROR_NONE: c_int = 0;
 pub const SSL_ERROR_SSL: c_int = 1;
 pub const SSL_ERROR_SYSCALL: c_int = 5;

--- a/openssl/CHANGELOG.md
+++ b/openssl/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+* Added the full set of `SslAlert` alert descriptions, along with `SslAlert::reason_code`, `SslAlert::from_reason_code`, and a `Display` implementation.
+
 ## [v0.10.81] - 2026-06-12
 
 ### Fixed

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -623,13 +623,8 @@ impl SniError {
 
 /// An SSL/TLS alert.
 ///
-/// These correspond to the alert descriptions from the IANA TLS Alert registry.
 /// The same values are used both to signal an alert from a callback and to
 /// identify an alert received from the peer via [`SslAlert::from_reason_code`].
-///
-/// See the [IANA TLS Alert registry] for the full list of alert descriptions.
-///
-/// [IANA TLS Alert registry]: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-6
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct SslAlert(c_int);
 
@@ -675,8 +670,6 @@ impl SslAlert {
 
     /// Returns the error reason code reported by [`Error::reason_code`] when
     /// this alert is received from the peer.
-    ///
-    /// This is the alert description plus `SSL_AD_REASON_OFFSET` (1000).
     ///
     /// [`Error::reason_code`]: crate::error::Error::reason_code
     pub fn reason_code(&self) -> c_int {

--- a/openssl/src/ssl/mod.rs
+++ b/openssl/src/ssl/mod.rs
@@ -622,14 +622,91 @@ impl SniError {
 }
 
 /// An SSL/TLS alert.
+///
+/// These correspond to the alert descriptions from the IANA TLS Alert registry.
+/// The same values are used both to signal an alert from a callback and to
+/// identify an alert received from the peer via [`SslAlert::from_reason_code`].
+///
+/// See the [IANA TLS Alert registry] for the full list of alert descriptions.
+///
+/// [IANA TLS Alert registry]: https://www.iana.org/assignments/tls-parameters/tls-parameters.xhtml#tls-parameters-6
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct SslAlert(c_int);
 
 impl SslAlert {
-    /// Alert 112 - `unrecognized_name`.
-    pub const UNRECOGNIZED_NAME: SslAlert = SslAlert(ffi::SSL_AD_UNRECOGNIZED_NAME);
+    pub const CLOSE_NOTIFY: SslAlert = SslAlert(ffi::SSL_AD_CLOSE_NOTIFY);
+    pub const UNEXPECTED_MESSAGE: SslAlert = SslAlert(ffi::SSL_AD_UNEXPECTED_MESSAGE);
+    pub const BAD_RECORD_MAC: SslAlert = SslAlert(ffi::SSL_AD_BAD_RECORD_MAC);
+    pub const DECRYPTION_FAILED: SslAlert = SslAlert(ffi::SSL_AD_DECRYPTION_FAILED);
+    pub const RECORD_OVERFLOW: SslAlert = SslAlert(ffi::SSL_AD_RECORD_OVERFLOW);
+    pub const DECOMPRESSION_FAILURE: SslAlert = SslAlert(ffi::SSL_AD_DECOMPRESSION_FAILURE);
+    pub const HANDSHAKE_FAILURE: SslAlert = SslAlert(ffi::SSL_AD_HANDSHAKE_FAILURE);
+    pub const NO_CERTIFICATE: SslAlert = SslAlert(ffi::SSL_AD_NO_CERTIFICATE);
+    pub const BAD_CERTIFICATE: SslAlert = SslAlert(ffi::SSL_AD_BAD_CERTIFICATE);
+    pub const UNSUPPORTED_CERTIFICATE: SslAlert = SslAlert(ffi::SSL_AD_UNSUPPORTED_CERTIFICATE);
+    pub const CERTIFICATE_REVOKED: SslAlert = SslAlert(ffi::SSL_AD_CERTIFICATE_REVOKED);
+    pub const CERTIFICATE_EXPIRED: SslAlert = SslAlert(ffi::SSL_AD_CERTIFICATE_EXPIRED);
+    pub const CERTIFICATE_UNKNOWN: SslAlert = SslAlert(ffi::SSL_AD_CERTIFICATE_UNKNOWN);
     pub const ILLEGAL_PARAMETER: SslAlert = SslAlert(ffi::SSL_AD_ILLEGAL_PARAMETER);
+    pub const UNKNOWN_CA: SslAlert = SslAlert(ffi::SSL_AD_UNKNOWN_CA);
+    pub const ACCESS_DENIED: SslAlert = SslAlert(ffi::SSL_AD_ACCESS_DENIED);
     pub const DECODE_ERROR: SslAlert = SslAlert(ffi::SSL_AD_DECODE_ERROR);
+    pub const DECRYPT_ERROR: SslAlert = SslAlert(ffi::SSL_AD_DECRYPT_ERROR);
+    pub const EXPORT_RESTRICTION: SslAlert = SslAlert(ffi::SSL_AD_EXPORT_RESTRICTION);
+    pub const PROTOCOL_VERSION: SslAlert = SslAlert(ffi::SSL_AD_PROTOCOL_VERSION);
+    pub const INSUFFICIENT_SECURITY: SslAlert = SslAlert(ffi::SSL_AD_INSUFFICIENT_SECURITY);
+    pub const INTERNAL_ERROR: SslAlert = SslAlert(ffi::SSL_AD_INTERNAL_ERROR);
+    pub const INAPPROPRIATE_FALLBACK: SslAlert = SslAlert(ffi::SSL_AD_INAPPROPRIATE_FALLBACK);
+    pub const USER_CANCELLED: SslAlert = SslAlert(ffi::SSL_AD_USER_CANCELLED);
+    pub const NO_RENEGOTIATION: SslAlert = SslAlert(ffi::SSL_AD_NO_RENEGOTIATION);
+    #[cfg(any(ossl111, libressl, boringssl, awslc))]
+    pub const MISSING_EXTENSION: SslAlert = SslAlert(ffi::SSL_AD_MISSING_EXTENSION);
+    pub const UNSUPPORTED_EXTENSION: SslAlert = SslAlert(ffi::SSL_AD_UNSUPPORTED_EXTENSION);
+    pub const CERTIFICATE_UNOBTAINABLE: SslAlert = SslAlert(ffi::SSL_AD_CERTIFICATE_UNOBTAINABLE);
+    pub const UNRECOGNIZED_NAME: SslAlert = SslAlert(ffi::SSL_AD_UNRECOGNIZED_NAME);
+    pub const BAD_CERTIFICATE_STATUS_RESPONSE: SslAlert =
+        SslAlert(ffi::SSL_AD_BAD_CERTIFICATE_STATUS_RESPONSE);
+    pub const BAD_CERTIFICATE_HASH_VALUE: SslAlert =
+        SslAlert(ffi::SSL_AD_BAD_CERTIFICATE_HASH_VALUE);
+    pub const UNKNOWN_PSK_IDENTITY: SslAlert = SslAlert(ffi::SSL_AD_UNKNOWN_PSK_IDENTITY);
+    #[cfg(any(ossl111, libressl, boringssl, awslc))]
+    pub const CERTIFICATE_REQUIRED: SslAlert = SslAlert(ffi::SSL_AD_CERTIFICATE_REQUIRED);
+    pub const NO_APPLICATION_PROTOCOL: SslAlert = SslAlert(ffi::SSL_AD_NO_APPLICATION_PROTOCOL);
+
+    /// Returns the error reason code reported by [`Error::reason_code`] when
+    /// this alert is received from the peer.
+    ///
+    /// This is the alert description plus `SSL_AD_REASON_OFFSET` (1000).
+    ///
+    /// [`Error::reason_code`]: crate::error::Error::reason_code
+    pub fn reason_code(&self) -> c_int {
+        self.0 + ffi::SSL_AD_REASON_OFFSET
+    }
+
+    /// Returns the alert corresponding to an [`Error::reason_code`], or `None`
+    /// if the reason code does not denote a received alert.
+    ///
+    /// [`Error::reason_code`]: crate::error::Error::reason_code
+    pub fn from_reason_code(reason: c_int) -> Option<SslAlert> {
+        let description = reason - ffi::SSL_AD_REASON_OFFSET;
+        if (0..=255).contains(&description) {
+            Some(SslAlert(description))
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for SslAlert {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // `SSL_alert_desc_string_long` always returns a valid, static,
+        // NUL-terminated ASCII string ("unknown" for unrecognized values).
+        let description = unsafe {
+            let ptr = ffi::SSL_alert_desc_string_long(self.0);
+            CStr::from_ptr(ptr).to_str().unwrap()
+        };
+        fmt.write_str(description)
+    }
 }
 
 /// An error returned from an ALPN selection callback.
@@ -4282,6 +4359,69 @@ cfg_if! {
             return ffi::SSL_get_ex_new_index(0, ptr::null_mut(), None, None, Some(f));
             #[cfg(any(boringssl, awslc))]
             return ffi::SSL_get_ex_new_index(0, ptr::null_mut(), ptr::null_mut(), None, f);
+        }
+    }
+}
+
+#[cfg(test)]
+mod alert_tests {
+    use super::SslAlert;
+
+    #[test]
+    fn reason_code_is_description_plus_offset() {
+        assert_eq!(SslAlert::CLOSE_NOTIFY.reason_code(), 1000);
+        assert_eq!(SslAlert::DECODE_ERROR.reason_code(), 1050);
+        assert_eq!(SslAlert(109).reason_code(), 1109);
+    }
+
+    #[test]
+    fn from_reason_code_maps_alerts() {
+        assert_eq!(
+            SslAlert::from_reason_code(1000),
+            Some(SslAlert::CLOSE_NOTIFY)
+        );
+        assert_eq!(
+            SslAlert::from_reason_code(1050),
+            Some(SslAlert::DECODE_ERROR)
+        );
+        // 1109 has no named `SSL_R_*` macro in BoringSSL/AWS-LC, but is still
+        // derived correctly from the alert description.
+        assert_eq!(SslAlert::from_reason_code(1109), Some(SslAlert(109)));
+    }
+
+    #[test]
+    fn from_reason_code_rejects_non_alert_codes() {
+        // Below the offset.
+        assert_eq!(SslAlert::from_reason_code(0), None);
+        assert_eq!(SslAlert::from_reason_code(267), None);
+        assert_eq!(SslAlert::from_reason_code(999), None);
+        // Above the highest possible alert description (offset + 255).
+        assert_eq!(SslAlert::from_reason_code(1256), None);
+    }
+
+    #[test]
+    fn display_uses_long_description() {
+        assert_eq!(SslAlert::CLOSE_NOTIFY.to_string(), "close notify");
+        assert_eq!(SslAlert::HANDSHAKE_FAILURE.to_string(), "handshake failure");
+        assert_eq!(SslAlert::DECODE_ERROR.to_string(), "decode error");
+        // Alerts OpenSSL does not name fall back to "unknown".
+        assert_eq!(SslAlert(255).to_string(), "unknown");
+    }
+
+    #[test]
+    fn reason_code_round_trips() {
+        let alerts = [
+            SslAlert::CLOSE_NOTIFY,
+            SslAlert::HANDSHAKE_FAILURE,
+            SslAlert::ILLEGAL_PARAMETER,
+            SslAlert::DECODE_ERROR,
+            SslAlert::UNRECOGNIZED_NAME,
+            SslAlert(109),
+            SslAlert(116),
+            SslAlert::NO_APPLICATION_PROTOCOL,
+        ];
+        for alert in alerts {
+            assert_eq!(SslAlert::from_reason_code(alert.reason_code()), Some(alert));
         }
     }
 }


### PR DESCRIPTION
Expose the complete IANA alert set on SslAlert, with reason_code / from_reason_code conversions and a Display implementation.